### PR TITLE
Avoid using System.out.println

### DIFF
--- a/api/src/main/java/net/labymod/serverapi/api/Protocol.java
+++ b/api/src/main/java/net/labymod/serverapi/api/Protocol.java
@@ -86,6 +86,13 @@ public class Protocol {
   }
 
   /**
+   * @return the protocol service of the protocol.
+   */
+  public final @NotNull AbstractProtocolService protocolService() {
+    return this.protocolService;
+  }
+
+  /**
    * Registers a packet to the protocol.
    *
    * @param id          The id of the packet.

--- a/api/src/main/java/net/labymod/serverapi/api/Protocol.java
+++ b/api/src/main/java/net/labymod/serverapi/api/Protocol.java
@@ -86,13 +86,6 @@ public class Protocol {
   }
 
   /**
-   * @return the protocol service of the protocol.
-   */
-  public final @NotNull AbstractProtocolService protocolService() {
-    return this.protocolService;
-  }
-
-  /**
    * Registers a packet to the protocol.
    *
    * @param id          The id of the packet.

--- a/api/src/main/java/net/labymod/serverapi/api/ProtocolRegistry.java
+++ b/api/src/main/java/net/labymod/serverapi/api/ProtocolRegistry.java
@@ -57,7 +57,7 @@ public class ProtocolRegistry {
   public void registerProtocol(@NotNull Protocol protocol) {
     Objects.requireNonNull(protocol, "Protocol cannot be null");
     this.protocols.add(protocol);
-    System.out.println("Registered protocol: " + protocol.identifier());
+    protocol.protocolService().logger().info("Registered protocol: " + protocol.identifier());
 
     for (Consumer<Protocol> registerListener : this.registerListeners) {
       registerListener.accept(protocol);

--- a/api/src/main/java/net/labymod/serverapi/api/ProtocolRegistry.java
+++ b/api/src/main/java/net/labymod/serverapi/api/ProtocolRegistry.java
@@ -57,7 +57,6 @@ public class ProtocolRegistry {
   public void registerProtocol(@NotNull Protocol protocol) {
     Objects.requireNonNull(protocol, "Protocol cannot be null");
     this.protocols.add(protocol);
-    protocol.protocolService().logger().info("Registered protocol: " + protocol.identifier());
 
     for (Consumer<Protocol> registerListener : this.registerListeners) {
       registerListener.accept(protocol);


### PR DESCRIPTION
* Adds `Protocol#protocolService` getter
* Removes warnings from Spigot for using `System.out/err.print`
![image](https://github.com/user-attachments/assets/7a7b88a6-288e-41e0-bd92-c3d415d13ab3)
